### PR TITLE
Build interactive onboarding course studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# TestGPT
-Testing codex
+# Onboarding Course Studio
+
+Design polished learning paths for new colleagues directly in the browser. The Course Studio lets you capture course goals, structure sections and lessons, and export onboarding plans for sharing.
+
+## Features
+
+- **Course dashboard** – switch between multiple courses, duplicate lessons, or remove drafts when they are no longer needed.
+- **Rich editor** – update titles, target audiences, goals, resources, and welcome notes with instant preview updates.
+- **Interactive learning path** – add sections, create diverse lesson types (video, workshop, quiz, etc.), and record durations, descriptions, and resources for each step.
+- **Participant preview** – review a beautifully formatted summary of the course so you know what learners will experience.
+- **Markdown export** – copy or download a shareable Markdown blueprint for distributing in wikis, onboarding guides, or email.
+- **Local storage** – your courses stay saved in the browser, so you can pick up where you left off.
+
+## Getting started
+
+1. Open `index.html` in your browser.
+2. Click **New course** to start a fresh onboarding track or select the pre-filled example.
+3. Fill in the course overview details and use the **Learning Path** panel to add sections and activities.
+4. Review the live preview and export the plan when you are ready to share.
+
+No build tools are required—the project is powered by plain HTML, CSS, and JavaScript.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,841 @@
+const STORAGE_KEY = "course-studio-v1";
+const LESSON_TYPES = [
+  "Welcome",
+  "Video",
+  "Article",
+  "Workshop",
+  "Interactive",
+  "Shadowing",
+  "Quiz",
+  "Reflection",
+];
+
+const state = {
+  courses: [],
+  selectedCourseId: null,
+};
+
+const courseListEl = document.querySelector("#course-list");
+const courseFormEl = document.querySelector("#course-form");
+const sectionsEl = document.querySelector("#sections");
+const previewEl = document.querySelector("#preview");
+const statusPillEl = document.querySelector("#status-pill");
+const toastEl = document.querySelector("#toast");
+
+init();
+
+function init() {
+  state.courses = loadCourses();
+  if (!state.courses.length) {
+    state.courses = [createSampleCourse()];
+  }
+  state.selectedCourseId = state.courses[0]?.id ?? null;
+
+  courseFormEl.addEventListener("input", handleCourseFormChange);
+  courseFormEl.addEventListener("change", handleCourseFormChange);
+  sectionsEl.addEventListener("input", handleSectionInput);
+  sectionsEl.addEventListener("change", handleSectionInput);
+  sectionsEl.addEventListener("click", handleSectionClick);
+  courseListEl.addEventListener("click", handleCourseListClick);
+
+  document
+    .querySelector("#new-course")
+    .addEventListener("click", handleCreateCourse);
+  document
+    .querySelector("#add-section")
+    .addEventListener("click", handleAddSection);
+  document
+    .querySelector("#export-plan")
+    .addEventListener("click", handleExport);
+
+  render();
+}
+
+function render() {
+  renderCourseList();
+  renderCourseForm();
+  renderSections();
+  renderPreview();
+  updateStatusPill();
+}
+
+function loadCourses() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return [];
+    const parsed = JSON.parse(stored);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((course) => ({
+      ...course,
+      sections: (course.sections || []).map((section) => ({
+        ...section,
+        lessons: (section.lessons || []).map((lesson) => ({ ...lesson })),
+      })),
+    }));
+  } catch (error) {
+    console.error("Failed to load courses", error);
+    return [];
+  }
+}
+
+function saveCourses() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state.courses));
+  } catch (error) {
+    console.error("Failed to save courses", error);
+  }
+}
+
+function handleCreateCourse() {
+  const newCourse = createBlankCourse();
+  state.courses.unshift(newCourse);
+  state.selectedCourseId = newCourse.id;
+  saveCourses();
+  render();
+  showToast("New course created. Start customizing the journey!");
+}
+
+function handleCourseListClick(event) {
+  const deleteButton = event.target.closest("button[data-action]");
+  if (deleteButton) {
+    const { action, courseId } = deleteButton.dataset;
+    if (action === "delete-course") {
+      event.stopPropagation();
+      deleteCourse(courseId);
+      return;
+    }
+  }
+
+  const card = event.target.closest("[data-course-id]");
+  if (!card) return;
+  const { courseId } = card.dataset;
+  if (courseId === state.selectedCourseId) return;
+  state.selectedCourseId = courseId;
+  render();
+}
+
+function deleteCourse(courseId) {
+  const index = state.courses.findIndex((course) => course.id === courseId);
+  if (index === -1) return;
+  const [removed] = state.courses.splice(index, 1);
+  if (removed?.id === state.selectedCourseId) {
+    state.selectedCourseId = state.courses[0]?.id ?? null;
+  }
+  saveCourses();
+  render();
+  showToast("Course removed from your studio.");
+}
+
+function handleAddSection() {
+  const course = getSelectedCourse();
+  if (!course) return;
+  const section = createBlankSection();
+  course.sections.push(section);
+  saveCourses();
+  renderSections();
+  renderCourseList();
+  renderPreview();
+  updateStatusPill();
+  showToast("Section added — add lessons to bring it to life.");
+}
+
+function handleCourseFormChange(event) {
+  const field = event.target.dataset.field;
+  if (!field) return;
+  const course = getSelectedCourse();
+  if (!course) return;
+  let value = event.target.value;
+  if (event.target.type === "number") {
+    value = value === "" ? "" : Number(value);
+  }
+  course[field] = value;
+  saveCourses();
+  if (field === "title" || field === "audience") {
+    renderCourseList();
+  }
+  renderPreview();
+  updateStatusPill();
+}
+
+function handleSectionInput(event) {
+  const field = event.target.dataset.field;
+  if (!field) return;
+  const course = getSelectedCourse();
+  if (!course) return;
+  const sectionId = event.target.dataset.sectionId;
+  const lessonId = event.target.dataset.lessonId;
+  if (!sectionId) return;
+  const section = course.sections.find((item) => item.id === sectionId);
+  if (!section) return;
+
+  if (!lessonId) {
+    section[field] = event.target.value;
+  } else {
+    const lesson = section.lessons.find((item) => item.id === lessonId);
+    if (!lesson) return;
+    let value = event.target.value;
+    if (event.target.type === "number") {
+      value = value === "" ? "" : Number(value);
+    }
+    lesson[field] = value;
+  }
+
+  saveCourses();
+  if (lessonId && field === "type") {
+    const lessonEl = event.target.closest(".lesson");
+    if (lessonEl) {
+      lessonEl.setAttribute("data-type", event.target.value || "Lesson");
+    }
+  }
+
+  if (field === "duration" || !lessonId) {
+    updateSectionMeta(sectionId);
+  }
+
+  renderCourseList();
+  renderPreview();
+  updateStatusPill();
+}
+
+function handleSectionClick(event) {
+  const actionButton = event.target.closest("button[data-action]");
+  if (!actionButton) return;
+  const { action, sectionId, lessonId } = actionButton.dataset;
+  const course = getSelectedCourse();
+  if (!course) return;
+  const section = course.sections.find((item) => item.id === sectionId);
+  if (!section) return;
+
+  if (action === "add-lesson") {
+    const lesson = createBlankLesson();
+    section.lessons.push(lesson);
+    saveCourses();
+    renderSections();
+    renderCourseList();
+    renderPreview();
+    updateStatusPill();
+    showToast("New activity added to this section.");
+    return;
+  }
+
+  if (action === "remove-section") {
+    course.sections = course.sections.filter((item) => item.id !== sectionId);
+    saveCourses();
+    renderSections();
+    renderCourseList();
+    renderPreview();
+    updateStatusPill();
+    showToast("Section removed.");
+    return;
+  }
+
+  if (action === "remove-lesson") {
+    section.lessons = section.lessons.filter((item) => item.id !== lessonId);
+    saveCourses();
+    renderSections();
+    renderCourseList();
+    renderPreview();
+    updateStatusPill();
+    showToast("Lesson removed from the journey.");
+    return;
+  }
+
+  if (action === "duplicate-lesson") {
+    const original = section.lessons.find((item) => item.id === lessonId);
+    if (!original) return;
+    const duplicate = {
+      ...structuredCloneSafe(original),
+      id: createId(),
+      title: `${original.title} (Copy)`,
+    };
+    section.lessons.push(duplicate);
+    saveCourses();
+    renderSections();
+    renderCourseList();
+    renderPreview();
+    showToast("Lesson duplicated for quick tweaks.");
+  }
+}
+
+function handleExport() {
+  const course = getSelectedCourse();
+  if (!course) {
+    showToast("Create or select a course to export.");
+    return;
+  }
+  const markdown = toMarkdown(course);
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard
+      .writeText(markdown)
+      .then(() => showToast("Course blueprint copied to clipboard!"))
+      .catch(() => downloadPlan(markdown));
+  } else {
+    downloadPlan(markdown);
+  }
+}
+
+function downloadPlan(content) {
+  const blob = new Blob([content], { type: "text/markdown" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "course-plan.md";
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+  showToast("Course plan downloaded as Markdown.");
+}
+
+function renderCourseList() {
+  if (!state.courses.length) {
+    courseListEl.innerHTML = `<div class="empty-state">Create your first course to begin.</div>`;
+    return;
+  }
+
+  courseListEl.innerHTML = state.courses
+    .map((course) => {
+      const totalLessons = course.sections.reduce(
+        (sum, section) => sum + section.lessons.length,
+        0,
+      );
+      const totalMinutes = course.sections.reduce(
+        (sum, section) =>
+          sum +
+          section.lessons.reduce(
+            (lessonSum, lesson) => lessonSum + Number(lesson.duration || 0),
+            0,
+          ),
+        0,
+      );
+      const isActive = course.id === state.selectedCourseId;
+      return `
+        <article class="course-card${isActive ? " active" : ""}" data-course-id="${escapeHtml(
+          course.id,
+        )}">
+          <div>
+            <h3>${escapeHtml(course.title || "Untitled onboarding")}</h3>
+            <p>${escapeHtml(course.audience || "Audience TBD")}</p>
+          </div>
+          <div class="course-meta">
+            <span>${course.sections.length} sections • ${totalLessons} lessons</span>
+            <span>${totalMinutes} mins</span>
+          </div>
+          <button
+            class="button small ghost"
+            data-action="delete-course"
+            data-course-id="${escapeHtml(course.id)}"
+            type="button"
+          >
+            Remove
+          </button>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderCourseForm() {
+  const course = getSelectedCourse();
+  const fields = courseFormEl.querySelectorAll("[data-field]");
+  if (!course) {
+    fields.forEach((field) => {
+      field.value = "";
+      field.disabled = true;
+    });
+    courseFormEl.classList.add("disabled");
+    return;
+  }
+
+  courseFormEl.classList.remove("disabled");
+  fields.forEach((field) => {
+    const key = field.dataset.field;
+    field.disabled = false;
+    const value = course[key];
+    if (field.type === "number") {
+      field.value = value === "" || value == null ? "" : value;
+    } else {
+      field.value = value ?? "";
+    }
+  });
+}
+
+function renderSections() {
+  const course = getSelectedCourse();
+  if (!course) {
+    sectionsEl.innerHTML = `<div class="empty-state">Select a course to design its learning path.</div>`;
+    return;
+  }
+
+  if (!course.sections.length) {
+    sectionsEl.innerHTML = `<div class="empty-state">Add your first section to kick off the curriculum.</div>`;
+    return;
+  }
+
+  sectionsEl.innerHTML = course.sections
+    .map((section, index) => {
+      const sectionDuration = section.lessons.reduce(
+        (sum, lesson) => sum + Number(lesson.duration || 0),
+        0,
+      );
+      const safeSectionId = escapeHtml(section.id);
+      const lessonsMarkup = section.lessons
+        .map((lesson, lessonIndex) =>
+          renderLesson(section.id, lesson, lessonIndex),
+        )
+        .join("");
+      return `
+        <div class="section" data-section-id="${safeSectionId}">
+          <div class="section-header">
+            <input
+              type="text"
+              class="section-title"
+              placeholder="Section title"
+              value="${escapeHtml(section.title || `Section ${index + 1}`)}"
+              data-field="title"
+              data-section-id="${safeSectionId}"
+            />
+            <div class="section-actions">
+              <button
+                class="button small ghost"
+                data-action="remove-section"
+                data-section-id="${safeSectionId}"
+                type="button"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+          <div class="section-meta">${section.lessons.length} lessons • ${sectionDuration} mins</div>
+          <div class="lessons">
+            ${lessonsMarkup || '<p class="section-meta">No activities yet. Add one below.</p>'}
+          </div>
+          <button
+            class="button small outline"
+            data-action="add-lesson"
+            data-section-id="${safeSectionId}"
+            type="button"
+          >
+            + Add activity
+          </button>
+        </div>
+      `;
+    })
+    .join("");
+}
+
+function renderLesson(sectionId, lesson, index) {
+  const safeSectionId = escapeHtml(sectionId);
+  const safeLessonId = escapeHtml(lesson.id);
+  return `
+    <article class="lesson" data-type="${escapeHtml(lesson.type || "Lesson")}">
+      <div class="lesson-row">
+        <input
+          type="text"
+          placeholder="Lesson ${index + 1} title"
+          value="${escapeHtml(lesson.title || "")}"
+          data-field="title"
+          data-section-id="${safeSectionId}"
+          data-lesson-id="${safeLessonId}"
+        />
+        <select
+          data-field="type"
+          data-section-id="${safeSectionId}"
+          data-lesson-id="${safeLessonId}"
+        >
+          ${LESSON_TYPES.map(
+            (type) => `
+              <option value="${escapeHtml(type)}"${lesson.type === type ? " selected" : ""}>${escapeHtml(type)}</option>
+            `,
+          ).join("")}
+        </select>
+        <input
+          type="number"
+          min="0"
+          step="5"
+          placeholder="mins"
+          value="${escapeHtml(lesson.duration ?? "")}"
+          data-field="duration"
+          data-section-id="${safeSectionId}"
+          data-lesson-id="${safeLessonId}"
+        />
+      </div>
+      <textarea
+        rows="3"
+        placeholder="What happens in this activity?"
+        data-field="summary"
+        data-section-id="${safeSectionId}"
+        data-lesson-id="${safeLessonId}"
+      >${escapeHtml(lesson.summary || "")}</textarea>
+      <textarea
+        rows="2"
+        placeholder="Resources or links learners should explore"
+        data-field="resources"
+        data-section-id="${safeSectionId}"
+        data-lesson-id="${safeLessonId}"
+      >${escapeHtml(lesson.resources || "")}</textarea>
+      <div class="lesson-actions">
+        <button
+          class="button small ghost"
+          data-action="duplicate-lesson"
+          data-section-id="${safeSectionId}"
+          data-lesson-id="${safeLessonId}"
+          type="button"
+        >
+          Duplicate
+        </button>
+        <button
+          class="button small ghost"
+          data-action="remove-lesson"
+          data-section-id="${safeSectionId}"
+          data-lesson-id="${safeLessonId}"
+          type="button"
+        >
+          Delete
+        </button>
+      </div>
+    </article>
+  `;
+}
+
+function renderPreview() {
+  const course = getSelectedCourse();
+  if (!course) {
+    previewEl.innerHTML = `<div class="empty-state">Select a course to see the participant preview.</div>`;
+    return;
+  }
+
+  const totalMinutes = course.sections.reduce(
+    (sum, section) =>
+      sum +
+      section.lessons.reduce(
+        (inner, lesson) => inner + Number(lesson.duration || 0),
+        0,
+      ),
+    0,
+  );
+
+  const previewHeader = `
+    <div class="preview-card">
+      <h3>${escapeHtml(course.title || "Untitled course")}</h3>
+      <div class="preview-meta">
+        <span><strong>Audience:</strong> ${escapeHtml(course.audience || "TBD")}</span>
+        <span><strong>Duration:</strong> ${course.duration || "?"} hrs planned • ${totalMinutes} mins detailed</span>
+      </div>
+      <p>${formatMultiline(course.welcome || "Welcome message coming soon!")}</p>
+    </div>
+  `;
+
+  const goalsCard = course.goals
+    ? `
+        <div class="preview-card">
+          <h3>Learning outcomes</h3>
+          ${formatList(course.goals)}
+        </div>
+      `
+    : "";
+
+  const resourcesCard = course.resources
+    ? `
+        <div class="preview-card">
+          <h3>Key resources</h3>
+          ${formatList(course.resources)}
+        </div>
+      `
+    : "";
+
+  const sectionsCards = course.sections.length
+    ? course.sections
+        .map((section, index) => {
+          const lessons = section.lessons.length
+            ? section.lessons
+                .map((lesson) => {
+                  const summary = lesson.summary
+                    ? `<p>${formatMultiline(lesson.summary)}</p>`
+                    : "";
+                  const resources = lesson.resources
+                    ? `<p class="preview-meta"><strong>Resources:</strong> ${formatMultiline(
+                        lesson.resources,
+                      )}</p>`
+                    : "";
+                  return `
+                    <li>
+                      <strong>${escapeHtml(lesson.title || "Untitled lesson")}</strong> • ${
+                        lesson.duration || 0
+                      } mins<br />
+                      <em>${escapeHtml(lesson.type || "Lesson")}</em>
+                      ${summary}
+                      ${resources}
+                    </li>
+                  `;
+                })
+                .join("")
+            : "<li><em>No activities scheduled yet.</em></li>";
+          return `
+            <div class="preview-card">
+              <h3>${index + 1}. ${escapeHtml(section.title || "Untitled section")}</h3>
+              <ul>${lessons}</ul>
+            </div>
+          `;
+        })
+        .join("")
+    : '<div class="preview-card"><p>No sections added yet. Use the Learning Path panel to start building.</p></div>';
+
+  previewEl.innerHTML =
+    previewHeader + goalsCard + resourcesCard + sectionsCards;
+}
+
+function updateStatusPill() {
+  const course = getSelectedCourse();
+  if (!course) {
+    statusPillEl.textContent = "No course selected";
+    statusPillEl.className = "status-pill draft";
+    return;
+  }
+
+  const hasSections = course.sections.length > 0;
+  const hasLessons = course.sections.every(
+    (section) => section.lessons.length > 0,
+  );
+  const hasDetails = Boolean(course.title && course.welcome && course.goals);
+
+  let status = "Draft";
+  let statusClass = "draft";
+
+  if (hasSections && hasLessons && hasDetails) {
+    status = "Launch ready";
+    statusClass = "ready";
+  } else if (hasSections && hasDetails) {
+    status = "In review";
+    statusClass = "review";
+  }
+
+  statusPillEl.textContent = status;
+  statusPillEl.className = `status-pill ${statusClass}`;
+}
+
+function updateSectionMeta(sectionId) {
+  const course = getSelectedCourse();
+  if (!course) return;
+  const section = course.sections.find((item) => item.id === sectionId);
+  if (!section) return;
+  const sectionEl = sectionsEl.querySelector(
+    `[data-section-id="${escapeSelector(sectionId)}"]`,
+  );
+  if (!sectionEl) return;
+  const totalMinutes = section.lessons.reduce(
+    (sum, lesson) => sum + Number(lesson.duration || 0),
+    0,
+  );
+  const metaEl = sectionEl.querySelector(".section-meta");
+  if (metaEl) {
+    metaEl.textContent = `${section.lessons.length} lessons • ${totalMinutes} mins`;
+  }
+}
+
+function createBlankCourse() {
+  const id = createId();
+  return {
+    id,
+    title: "Untitled onboarding",
+    audience: "",
+    goals: "",
+    resources: "",
+    welcome: "",
+    duration: "",
+    sections: [createBlankSection()],
+  };
+}
+
+function createBlankSection() {
+  return {
+    id: createId(),
+    title: "New section",
+    lessons: [createBlankLesson()],
+  };
+}
+
+function createBlankLesson() {
+  return {
+    id: createId(),
+    title: "New lesson",
+    type: LESSON_TYPES[0],
+    duration: 15,
+    summary: "",
+    resources: "",
+  };
+}
+
+function createSampleCourse() {
+  return {
+    id: createId(),
+    title: "New Hire Essentials",
+    audience: "Colleagues joining the product team",
+    goals:
+      "- Understand our customers and product vision\n- Navigate the core toolkit confidently\n- Build relationships across the squad",
+    resources:
+      "- Employee handbook\n- Product demo environment\n- Slack channel #product-academy",
+    welcome:
+      "Welcome to the team! This two-day experience will help you connect with our mission and gain the confidence to start shipping value.",
+    duration: 8,
+    sections: [
+      {
+        id: createId(),
+        title: "Kick-off & Culture",
+        lessons: [
+          {
+            id: createId(),
+            title: "Live welcome session",
+            type: "Workshop",
+            duration: 60,
+            summary:
+              "Meet the leadership team, review our mission, and set expectations for the first month.",
+            resources: "Presentation deck\nLeadership bios",
+          },
+          {
+            id: createId(),
+            title: "Company scavenger hunt",
+            type: "Interactive",
+            duration: 40,
+            summary:
+              "Pair up with another new hire to explore our handbook, wiki, and communication channels.",
+            resources: "Employee handbook\nIntranet access",
+          },
+        ],
+      },
+      {
+        id: createId(),
+        title: "Product Deep Dive",
+        lessons: [
+          {
+            id: createId(),
+            title: "Product demo walkthrough",
+            type: "Video",
+            duration: 45,
+            summary:
+              "Product lead walks through the roadmap, personas, and the value proposition of our flagship solution.",
+            resources: "Demo recording\nProduct brief",
+          },
+          {
+            id: createId(),
+            title: "Shadow a customer call",
+            type: "Shadowing",
+            duration: 30,
+            summary:
+              "Listen in on a recorded discovery call to understand customer challenges.",
+            resources: "Recorded Zoom session\nCustomer profile snapshot",
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function getSelectedCourse() {
+  return (
+    state.courses.find((course) => course.id === state.selectedCourseId) ?? null
+  );
+}
+
+function createId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(16).slice(2)}-${Date.now()}`;
+}
+
+function escapeHtml(value) {
+  if (value == null) return "";
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function escapeSelector(value) {
+  if (typeof CSS !== "undefined" && CSS.escape) {
+    return CSS.escape(value);
+  }
+  return String(value).replace(/([.#:[\],])/g, "\\$1");
+}
+
+function formatMultiline(text) {
+  return escapeHtml(text).replace(/\n/g, "<br />");
+}
+
+function formatList(text) {
+  const items = text
+    .split(/\n+/)
+    .map((item) => item.trim())
+    .filter(Boolean);
+  if (!items.length) {
+    return `<p>${escapeHtml(text)}</p>`;
+  }
+  return `<ul>${items.map((item) => `<li>${escapeHtml(item)}</li>`).join("")}</ul>`;
+}
+
+function toMarkdown(course) {
+  const lines = [];
+  lines.push(`# ${course.title || "Untitled course"}`);
+  lines.push("");
+  if (course.audience) {
+    lines.push(`**Audience:** ${course.audience}`);
+  }
+  if (course.duration) {
+    lines.push(`**Planned duration:** ${course.duration} hrs`);
+  }
+  lines.push("");
+  if (course.welcome) {
+    lines.push(course.welcome);
+    lines.push("");
+  }
+  if (course.goals) {
+    lines.push("## Learning outcomes");
+    lines.push("");
+    lines.push(course.goals);
+    lines.push("");
+  }
+  if (course.resources) {
+    lines.push("## Key resources");
+    lines.push("");
+    lines.push(course.resources);
+    lines.push("");
+  }
+  course.sections.forEach((section, sectionIndex) => {
+    lines.push(
+      `## ${sectionIndex + 1}. ${section.title || "Untitled section"}`,
+    );
+    lines.push("");
+    section.lessons.forEach((lesson, lessonIndex) => {
+      lines.push(
+        `${sectionIndex + 1}.${lessonIndex + 1} ${lesson.title || "Untitled lesson"} (${lesson.type || "Lesson"} • ${lesson.duration || 0} mins)`,
+      );
+      if (lesson.summary) {
+        lines.push(`> ${lesson.summary.replace(/\n/g, "\n> ")}`);
+      }
+      if (lesson.resources) {
+        lines.push(`Resources: ${lesson.resources}`);
+      }
+      lines.push("");
+    });
+  });
+  return lines.join("\n");
+}
+
+function showToast(message) {
+  toastEl.textContent = message;
+  toastEl.classList.add("show");
+  clearTimeout(showToast.timeoutId);
+  showToast.timeoutId = setTimeout(() => {
+    toastEl.classList.remove("show");
+  }, 2200);
+}
+
+function structuredCloneSafe(value) {
+  if (typeof structuredClone === "function") {
+    return structuredClone(value);
+  }
+  return JSON.parse(JSON.stringify(value));
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Onboarding Course Studio</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <div class="app" id="app">
+      <aside class="sidebar">
+        <div class="brand">
+          <div class="brand-logo" aria-hidden="true">🎓</div>
+          <div class="brand-text">
+            <h1>Course Studio</h1>
+            <p>Craft onboarding journeys with ease.</p>
+          </div>
+        </div>
+        <button class="button primary" id="new-course" type="button">
+          + New course
+        </button>
+        <div class="course-filters" aria-hidden="true">
+          <span class="chip">Onboarding</span>
+          <span class="chip">Productivity</span>
+          <span class="chip">Culture</span>
+        </div>
+        <div class="course-list" id="course-list"></div>
+      </aside>
+      <main class="workspace" aria-live="polite">
+        <section class="panel" id="overview-panel">
+          <header class="panel-header">
+            <div>
+              <h2>Course Overview</h2>
+              <p class="subtitle">
+                Define the learning experience for your new teammates.
+              </p>
+            </div>
+            <span class="status-pill" id="status-pill">Draft</span>
+          </header>
+          <form class="stack" id="course-form">
+            <label class="field">
+              <span>Course title</span>
+              <input
+                type="text"
+                placeholder="e.g. Product Onboarding Accelerator"
+                data-field="title"
+                required
+              />
+            </label>
+            <div class="grid two">
+              <label class="field">
+                <span>Target audience</span>
+                <input
+                  type="text"
+                  placeholder="New product specialists"
+                  data-field="audience"
+                />
+              </label>
+              <label class="field">
+                <span>Suggested duration (hrs)</span>
+                <input type="number" min="1" step="0.5" data-field="duration" />
+              </label>
+            </div>
+            <label class="field">
+              <span>Learning goals</span>
+              <textarea
+                rows="3"
+                placeholder="Describe what success looks like after this course"
+                data-field="goals"
+              ></textarea>
+            </label>
+            <label class="field">
+              <span>Key tools & resources</span>
+              <textarea
+                rows="2"
+                placeholder="List the tools or documents participants will need"
+                data-field="resources"
+              ></textarea>
+            </label>
+            <label class="field">
+              <span>Welcome message</span>
+              <textarea
+                rows="3"
+                placeholder="Give learners a warm welcome and set expectations"
+                data-field="welcome"
+              ></textarea>
+            </label>
+          </form>
+        </section>
+        <section class="panel" id="structure-panel">
+          <header class="panel-header">
+            <div>
+              <h2>Learning Path</h2>
+              <p class="subtitle">
+                Curate sections, lessons, and interactive touchpoints.
+              </p>
+            </div>
+            <button class="button ghost" id="add-section" type="button">
+              + Add section
+            </button>
+          </header>
+          <div class="sections" id="sections"></div>
+        </section>
+        <section class="panel preview" id="preview-panel">
+          <header class="panel-header">
+            <div>
+              <h2>Participant Preview</h2>
+              <p class="subtitle">
+                Share this snapshot or export it as onboarding notes.
+              </p>
+            </div>
+            <button class="button outline" id="export-plan" type="button">
+              Export plan
+            </button>
+          </header>
+          <div class="preview-content" id="preview"></div>
+        </section>
+      </main>
+    </div>
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,545 @@
+:root {
+  color-scheme: light;
+  --bg: #f4f6fb;
+  --surface: #ffffff;
+  --border: rgba(32, 45, 64, 0.1);
+  --accent: #5856d6;
+  --accent-soft: rgba(88, 86, 214, 0.12);
+  --accent-strong: rgba(88, 86, 214, 0.2);
+  --text: #1c2333;
+  --text-muted: rgba(28, 35, 51, 0.65);
+  --success: #0baa6c;
+  --danger: #ff5a5f;
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+  font-family:
+    "Inter",
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top right, #eef1ff, var(--bg) 40%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(circle at 10% 10%, rgba(88, 86, 214, 0.1), transparent 40%),
+    radial-gradient(
+      circle at 90% 20%,
+      rgba(62, 140, 245, 0.12),
+      transparent 45%
+    ),
+    radial-gradient(
+      circle at 50% 100%,
+      rgba(255, 173, 94, 0.15),
+      transparent 50%
+    );
+  z-index: -2;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background: rgba(255, 255, 255, 0.5);
+  z-index: -1;
+  backdrop-filter: blur(60px);
+}
+
+.app {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr);
+  min-height: 100vh;
+}
+
+.sidebar {
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(40px);
+  border-right: 1px solid var(--border);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.brand {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.brand-logo {
+  width: 56px;
+  height: 56px;
+  display: grid;
+  place-content: center;
+  background: var(--accent-strong);
+  border-radius: 18px;
+  font-size: 28px;
+}
+
+.brand-text h1 {
+  font-size: 20px;
+  font-weight: 700;
+  margin: 0;
+}
+
+.brand-text p {
+  margin: 4px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  border-radius: 14px;
+  padding: 12px 18px;
+  border: 1px solid transparent;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  font-weight: 600;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.15s ease,
+    background-color 0.2s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, #6c5ce7, #5c7cfa);
+  color: #fff;
+  box-shadow: 0 18px 30px rgba(92, 124, 250, 0.25);
+}
+
+.button.primary:hover,
+.button.primary:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 24px 32px rgba(92, 124, 250, 0.3);
+}
+
+.button.ghost {
+  background: transparent;
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.button.ghost:hover {
+  background: var(--accent-soft);
+}
+
+.button.outline {
+  background: #fff;
+  border-color: rgba(92, 124, 250, 0.3);
+  color: var(--accent);
+}
+
+.button.outline:hover {
+  border-color: var(--accent);
+}
+
+.button.small {
+  padding: 8px 12px;
+  border-radius: 10px;
+  font-size: 13px;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 32px;
+  gap: 24px;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 28px;
+  border: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: var(--shadow);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  position: relative;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.subtitle {
+  margin: 8px 0 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(11, 170, 108, 0.14);
+  color: var(--success);
+  font-weight: 600;
+  font-size: 13px;
+}
+
+.status-pill.draft {
+  background: rgba(255, 90, 95, 0.16);
+  color: var(--danger);
+}
+
+.status-pill.review {
+  background: rgba(92, 124, 250, 0.18);
+  color: var(--accent);
+}
+
+.status-pill.ready {
+  background: rgba(11, 170, 108, 0.18);
+  color: var(--success);
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.grid.two {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 14px;
+}
+
+.field span {
+  color: var(--text-muted);
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.field input,
+.field textarea,
+.section input,
+.section textarea,
+.section select {
+  padding: 12px 14px;
+  border-radius: 14px;
+  border: 1px solid rgba(28, 35, 51, 0.1);
+  background: rgba(255, 255, 255, 0.8);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.05);
+  font: inherit;
+  resize: vertical;
+  color: var(--text);
+}
+
+.field textarea,
+.section textarea {
+  line-height: 1.5;
+}
+
+.field input:focus,
+.field textarea:focus,
+.section input:focus,
+.section textarea:focus,
+.section select:focus {
+  outline: none;
+  border-color: rgba(92, 124, 250, 0.6);
+  box-shadow: 0 0 0 3px rgba(92, 124, 250, 0.2);
+}
+
+.course-list {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+.course-card {
+  border-radius: 20px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.7);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  cursor: pointer;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease,
+    border-color 0.2s ease;
+}
+
+.course-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.1);
+}
+
+.course-card.active {
+  border-color: var(--accent);
+  box-shadow: 0 16px 30px rgba(92, 124, 250, 0.22);
+}
+
+.course-card h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.course-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.course-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(28, 35, 51, 0.08);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.course-filters {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sections {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.section {
+  background: rgba(247, 248, 255, 0.88);
+  border: 1px solid rgba(92, 124, 250, 0.18);
+  border-radius: 24px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.section-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.section-header h3 {
+  margin: 0;
+  font-size: 16px;
+}
+
+.section-meta {
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.section-actions {
+  display: flex;
+  gap: 8px;
+}
+
+.lessons {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.lesson {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 18px;
+  border: 1px solid rgba(92, 124, 250, 0.12);
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  position: relative;
+}
+
+.lesson::before {
+  content: attr(data-type);
+  position: absolute;
+  top: -10px;
+  left: 16px;
+  background: rgba(92, 124, 250, 0.18);
+  color: var(--accent);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 4px 12px;
+  border-radius: 999px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.lesson-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 130px 120px;
+  gap: 12px;
+  align-items: center;
+}
+
+.lesson textarea {
+  min-height: 72px;
+}
+
+.lesson-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.preview-content {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.preview-card {
+  background: rgba(247, 248, 255, 0.88);
+  border-radius: 20px;
+  padding: 18px;
+  border: 1px solid rgba(92, 124, 250, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.preview-card h3 {
+  margin: 0 0 12px;
+  font-size: 16px;
+}
+
+.preview-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.preview-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.preview-meta strong {
+  color: var(--text);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-muted);
+}
+
+.toast {
+  position: fixed;
+  bottom: 24px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: #fff;
+  padding: 14px 18px;
+  border-radius: 999px;
+  box-shadow: 0 18px 30px rgba(15, 23, 42, 0.18);
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 0.3s ease,
+    transform 0.3s ease;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0px);
+}
+
+@media (max-width: 1024px) {
+  .app {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: sticky;
+    top: 0;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    overflow-x: auto;
+  }
+
+  .brand-text h1 {
+    font-size: 18px;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .workspace {
+    padding: 18px;
+  }
+
+  .panel {
+    padding: 22px;
+  }
+
+  .lesson-row {
+    grid-template-columns: 1fr;
+  }
+
+  .grid.two {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page course studio layout with overview, learning path, and preview panels
- implement modern styling and responsive design for the authoring experience
- build client-side logic for managing courses, local storage, live previews, and markdown export

## Testing
- `npx --yes prettier --check index.html styles.css app.js README.md`


------
https://chatgpt.com/codex/tasks/task_e_68cadc7fd6c8832a966ef4acb49ebead