### PR TITLE
Add terminal flashcard game with sample deck

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# TestGPT
-Testing codex
+# Flashcard Study Game
+
+A simple terminal-based flashcard game to help you study using JSON decks.
+
+## Features
+- Load flashcards from a JSON file (sample deck included)
+- Optional shuffling and card limits for shorter sessions
+- Filter cards by tags for focused practice
+- List selected cards without starting a quiz
+
+## Getting Started
+1. Ensure you have Python 3.8+ installed.
+2. Run the game with the included sample deck:
+   ```bash
+   python flashcard_game.py --deck data/sample_deck.json
+   ```
+
+## Commands and Options
+- `--deck PATH` – Path to a JSON deck file (default: `data/sample_deck.json`).
+- `--shuffle` – Shuffle the deck before quizzing.
+- `--limit N` – Limit the number of cards shown in the session.
+- `--tags tag1,tag2` – Filter cards by comma-separated tags.
+- `--list` – List the selected cards instead of running a quiz.
+
+Example: practice only programming cards, shuffled and limited to three:
+```bash
+python flashcard_game.py --tags programming --shuffle --limit 3
+```
+
+## Deck Format
+Decks are JSON arrays where each object represents a card:
+```json
+{
+  "question": "What is the capital of France?",
+  "answer": "Paris",
+  "hint": "It's known as the City of Light.",
+  "tags": ["geography", "europe"]
+}
+```
+Only `question` and `answer` are required; `hint` and `tags` are optional.
+
+## Contributing Your Own Deck
+1. Copy `data/sample_deck.json` to a new file, e.g., `my_deck.json`.
+2. Add or edit cards following the format above.
+3. Run the game with your deck:
+   ```bash
+   python flashcard_game.py --deck my_deck.json --shuffle
+   ```

--- a/data/sample_deck.json
+++ b/data/sample_deck.json
@@ -1,0 +1,24 @@
+[
+  {
+    "question": "What is the capital of France?",
+    "answer": "Paris",
+    "hint": "It's known as the City of Light.",
+    "tags": ["geography", "europe"]
+  },
+  {
+    "question": "Define encapsulation in object-oriented programming.",
+    "answer": "Encapsulation is the bundling of data with the methods that operate on that data while restricting direct access to some of the object's components.",
+    "hint": "It often involves access modifiers like private or public.",
+    "tags": ["programming", "oop"]
+  },
+  {
+    "question": "What does HTTP stand for?",
+    "answer": "HyperText Transfer Protocol",
+    "tags": ["web", "networking"]
+  },
+  {
+    "question": "Name the process plants use to convert sunlight into chemical energy.",
+    "answer": "Photosynthesis",
+    "tags": ["biology"]
+  }
+]

--- a/flashcard_game.py
+++ b/flashcard_game.py
@@ -1,0 +1,172 @@
+"""A simple terminal flashcard game for studying.
+
+Usage examples:
+    python flashcard_game.py --deck data/sample_deck.json --shuffle
+    python flashcard_game.py --deck my_deck.json --limit 5 --tags oop,web
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import random
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Optional, Sequence
+
+
+@dataclass
+class Card:
+    question: str
+    answer: str
+    hint: Optional[str] = None
+    tags: Optional[List[str]] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "Card":
+        if "question" not in data or "answer" not in data:
+            raise ValueError("Each card must include 'question' and 'answer' fields")
+        tags = data.get("tags")
+        if tags is not None and not isinstance(tags, list):
+            raise ValueError("'tags' must be a list of strings if provided")
+        return cls(
+            question=str(data["question"]),
+            answer=str(data["answer"]),
+            hint=str(data.get("hint")) if data.get("hint") is not None else None,
+            tags=[str(tag) for tag in tags] if tags else None,
+        )
+
+
+class Deck:
+    def __init__(self, cards: Sequence[Card]):
+        if not cards:
+            raise ValueError("Deck cannot be empty")
+        self.cards: List[Card] = list(cards)
+
+    def filter_by_tags(self, tags: Iterable[str]) -> "Deck":
+        tag_set = {tag.strip().lower() for tag in tags if tag.strip()}
+        if not tag_set:
+            return self
+        filtered_cards = [
+            card
+            for card in self.cards
+            if card.tags and tag_set.intersection({t.lower() for t in card.tags})
+        ]
+        if not filtered_cards:
+            raise ValueError("No cards found with the provided tag filters")
+        return Deck(filtered_cards)
+
+    def shuffled(self) -> "Deck":
+        cards = list(self.cards)
+        random.shuffle(cards)
+        return Deck(cards)
+
+    def limited(self, limit: Optional[int]) -> "Deck":
+        if limit is None:
+            return self
+        if limit <= 0:
+            raise ValueError("Limit must be a positive integer")
+        return Deck(self.cards[:limit])
+
+
+class Quiz:
+    def __init__(self, deck: Deck):
+        self.deck = deck
+        self.correct = 0
+        self.total = 0
+
+    def _prompt(self, prompt: str) -> str:
+        try:
+            return input(prompt)
+        except EOFError:
+            print("\nSession ended.")
+            raise SystemExit(0)
+
+    def run(self) -> None:
+        for card in self.deck.cards:
+            self.total += 1
+            print(f"\nCard {self.total}/{len(self.deck.cards)}")
+            print("Q:", card.question)
+            if card.hint:
+                see_hint = self._prompt("See hint? (y/N) ")
+                if see_hint.lower().startswith("y"):
+                    print("Hint:", card.hint)
+            response = self._prompt("Your answer: ")
+            if response.strip().lower() == card.answer.strip().lower():
+                self.correct += 1
+                print("✅ Correct!")
+            else:
+                print("❌ Not quite. Correct answer:", card.answer)
+        print("\nSession complete!")
+        print(f"Score: {self.correct}/{self.total} correct")
+
+
+def load_deck(path: Path) -> Deck:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, list):
+        raise ValueError("Deck file must contain a JSON list of cards")
+    cards = [Card.from_dict(item) for item in data]
+    return Deck(cards)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Terminal flashcard study helper")
+    parser.add_argument(
+        "--deck",
+        type=Path,
+        default=Path("data/sample_deck.json"),
+        help="Path to a JSON file containing flashcards",
+    )
+    parser.add_argument(
+        "--shuffle",
+        action="store_true",
+        help="Shuffle the deck before quizzing",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Limit the number of cards for this session",
+    )
+    parser.add_argument(
+        "--tags",
+        type=str,
+        help="Comma-separated list of tags to filter the deck",
+    )
+    parser.add_argument(
+        "--list",
+        dest="list_only",
+        action="store_true",
+        help="List the selected cards without starting a quiz",
+    )
+    return parser.parse_args(argv)
+
+
+def build_deck(args: argparse.Namespace) -> Deck:
+    deck = load_deck(args.deck)
+    if args.tags:
+        deck = deck.filter_by_tags(args.tags.split(","))
+    if args.shuffle:
+        deck = deck.shuffled()
+    deck = deck.limited(args.limit)
+    return deck
+
+
+def list_cards(deck: Deck) -> None:
+    for idx, card in enumerate(deck.cards, start=1):
+        tags = f" [tags: {', '.join(card.tags)}]" if card.tags else ""
+        print(f"{idx}. {card.question}{tags}")
+
+
+def main(argv: Optional[Sequence[str]] = None) -> None:
+    args = parse_args(argv or sys.argv[1:])
+    deck = build_deck(args)
+    if args.list_only:
+        list_cards(deck)
+        return
+    quiz = Quiz(deck)
+    quiz.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python terminal flashcard game with shuffling, limits, and tag filtering
- provide a sample JSON deck and usage documentation in README

## Testing
- python flashcard_game.py --list --limit 2

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c34807f0c832a9a28ed2a747ebfe7)